### PR TITLE
Add .NET Aspire skeleton

### DIFF
--- a/Codex.sln
+++ b/Codex.sln
@@ -1,0 +1,11 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codex.AppHost", "src/Codex.AppHost/Codex.AppHost.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codex.Web", "src/Codex.Web/Codex.Web.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # Codex
-Developing an application using Codex.
+
+This repository contains a sample .NET Aspire project targeting **.NET 9**. The structure was created without the `dotnet` CLI so you may need to adjust it to your environment.
+
+## Structure
+
+- `Directory.Build.props` &mdash; sets the default target framework to `net9.0` for all projects.
+- `src/Codex.AppHost` &mdash; console host referencing the web project.
+- `src/Codex.Web` &mdash; minimal ASP.NET Core web application.
+
+## Building
+
+Install a .NET 9 SDK and run:
+
+```bash
+dotnet build Codex.sln
+```
+
+## Running
+
+```bash
+dotnet run --project src/Codex.Web/Codex.Web.csproj
+```

--- a/src/Codex.AppHost/Codex.AppHost.csproj
+++ b/src/Codex.AppHost/Codex.AppHost.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Codex.Web/Codex.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Codex.Web/Codex.Web.csproj
+++ b/src/Codex.Web/Codex.Web.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+</Project>

--- a/src/Codex.Web/Program.cs
+++ b/src/Codex.Web/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello from Codex Aspire Net9!");
+
+app.Run();


### PR DESCRIPTION
## Summary
- add sample .NET Aspire project targeting .NET 9

## Testing
- `dotnet build Codex.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853bed39d08832192f18e8fe5923846